### PR TITLE
Add ability to limit authentication by domain and disallow automatic registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ Restart n8n to pick up the environment var changes + the new hooks.js.
 
 ### Optional
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `OIDC_SCOPES` | `openid email profile` | Space-separated list of OIDC scopes |
+| Variable                  | Default                | Description                                                                            |
+|---------------------------|------------------------|----------------------------------------------------------------------------------------|
+| `OIDC_SCOPES`             | `openid email profile` | Space-separated list of OIDC scopes                                                    |
+| `OIDC_DOMAINS`            | `null`                 | Comma-separated list of domains to allow OIDC login. Leave blank to allow all domains. |
+| `OIDC_ALLOW_REGISTRATION` | `true`                 | Allow users to register new accounts                                                   |
 
 ## How It Works
 

--- a/hooks.js
+++ b/hooks.js
@@ -16,6 +16,8 @@
  *
  * Optional:
  * - OIDC_SCOPES: Space-separated list of scopes (default: "openid email profile")
+ * - OIDC_DOMAINS: Comma-separated list of allowed domains (default: allows all domains)
+ * - OIDC_ALLOW_REGISTRATION: Setting to false will disable registration when the user is not found (default: true)
  */
 
 const https = require('https');
@@ -30,6 +32,8 @@ const config = {
   clientSecret: process.env.OIDC_CLIENT_SECRET,
   redirectUri: process.env.OIDC_REDIRECT_URI,
   scopes: process.env.OIDC_SCOPES || 'openid email profile',
+  domains: process.env.OIDC_DOMAINS || null,
+  allowRegistration: (process.env.OIDC_ALLOW_REGISTRATION || 'true') === 'true',
 };
 
 // Validate configuration
@@ -300,13 +304,18 @@ function createUserHash(user) {
 }
 
 /**
- * Check if email is valid
+ * Check if the email is valid and (optionally) matches the configured domain.
  * @param {string} email
  * @returns {boolean}
  */
 function isValidEmail(email) {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(email);
+  if (!emailRegex.test(email)) {
+    return false;
+  }
+
+  return !config.domains
+    || config.domains.split(',').map(domain => domain.trim()).includes(email.split('@')[1]);
 }
 
 // n8n module paths (specific to the Docker image)
@@ -462,6 +471,11 @@ module.exports = {
             });
 
             if (!user) {
+              // Return an error if registration is disabled
+              if (!config.allowRegistration) {
+                return res.redirect('/signin?error=' + encodeURIComponent('User not found and registration is disabled'));
+              }
+
               // Check if this is the first user (should be owner)
               const userCount = await User.count();
 


### PR DESCRIPTION
# Domain and Registration Control
This PR adds the ability to 1) limit OIDC users by their email domain and 2) disallow automatic registration of a user when not found.

## Changes made
- Added `OIDC_DOMAINS` envvar to provide a comma-separated list of allowed domains. When the email is validated, it will also check that the validated email has a valid domain.
- Added `OIDC_ALLOW_REGISTRATION` envvar that, when set to "false", will show an error if the OIDC user was not found in the Users DB.
- Updated `README.md` to reflect new optional envvars.

## Testing
- Not including `OIDC_DOMAINS` and `OIDC_ALLOW_REGISTRATION` maintains current functionality
- Including a single domain in `OIDC_DOMAINS` throws an error when the email does not contain the domain
- Including a comma-separated list of domains in `OIDC_DOMAINS` works for both domains provided
- Including `OIDC_ALLOW_REGISTRATION` and setting it to "false" does not create users and throws an error
- Including `OIDC_ALLOW_REGISTRATION` and setting it to "true" maintains current functionality